### PR TITLE
feat: fetch-only-when-changed for work-details (v0.2.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -153,9 +153,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -214,25 +214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,12 +243,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -489,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -624,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64",
  "bytes",
@@ -766,6 +741,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +788,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -899,6 +891,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,12 +974,14 @@ dependencies = [
  "futures",
  "governor",
  "orcid-works-model",
- "rayon",
  "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
+ "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -987,6 +991,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1192,26 +1202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64",
  "bytes",
@@ -1305,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "once_cell",
  "ring",
@@ -1329,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1440,6 +1430,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1583,6 +1582,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,15 +1617,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -1719,7 +1729,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1729,6 +1751,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1771,6 +1819,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
 # ORCID Fetcher CLI
-
-A third-party CLI toolkit for downloading public data from the ORCID API  
-(*initial release: Work Details only – more record types will follow*).
+A third-party CLI toolkit for downloading public data from the ORCID API.
 
 ## Features
 - Fetch **all Work Details** for a given ORCID iD (v 3.0 API)
 - Pretty-printed JSON written to any directory you choose
-- Safe "write-only-when-changed" logic (ideal for Git repos)
+- Safe "fetch-only-when-changed" logic
+  - compares existing work-details with the latest summaries and downloads *only* new or updated entries; no file rewrite when unchanged
+  - ideal for static hosting (e.g. GitHub Pages)
 
-## Build
+(*initial release: Work Details only – more record types will follow*).
 
+## Installation
+### Dependencies
+- Rust ≥ 1.88
+  ```bash
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+  ```
+
+### Build
 ```bash
 git clone https://github.com/hyperfinitism/orcid-fetcher
 cd orcid-fetcher
@@ -19,21 +27,20 @@ cargo build --release
 ## Usage
 
 ### `orcid-works-cli`
-#### Usage
+#### Command
 ```bash
-orcid-works-cli \
-    --id 3141-5926-5358-9793 \
-    --out ./output.json
+orcid-works-cli --id $ORCID_iD [Options]
 ```
 
-#### Flags
+#### Options
 | Flag | Description | Default |
 | :--- | :---------- | :------ |
-| `-i`, `--id` \<string\> | ORCID iD (e.g. `3141-5926-5358-9793`) | *(required)* |
-| `-o`, `--out` \<path\> | Output JSON file path (parent dirs auto-created) | `./output.json` |
-| `--concurrency` \<usize\> | Maximum parallel requests | `10` |
-| `--rate-limit` \<u32\> | Requests-per-second cap (1–40) | `12` |
-| `--user-agent-note` \<string\> | Text appended to the built-in User-Agent string | *(none)* |
+| `-i`, `--id` \<String\> | ORCID iD (e.g. `3141-5926-5358-9793`) | *(required)* |
+| `-o`, `--out` \<PathBuf\> | Output JSON file path (parent dirs auto-created) | `./output.json` |
+| `--concurrency` \<usize\> | Maximum parallel requests (1-32). Should not exceed rate-limit. | `8` |
+| `--rate-limit` \<u32\> | Requests-per-second cap (1–40). See [Guidelines](#guidelines) section. | `12` |
+| `--user-agent-note` \<String\> | Text appended to the built-in User-Agent string | *(none)* |
+| `--force-fetch` | Ignore diff and refetch every work-detail entry | `false` |
 | `-h`, `--help` | Print help | — |
 | `-V`, `--version` | Print version | — |
 
@@ -43,7 +50,14 @@ orcid-works-cli \
 * **(none)** – optional, nothing is sent if omitted  
 * any other value – used as default when the flag is absent
 
-## ⚠️ Guidelines
+#### Example
+```bash
+orcid-works-cli \
+    --id 3141-5926-5358-9793 \
+    --out ./output.json
+```
+
+## Guidelines
 Please respect ORCID's Public API policies:
 
 - **Rate limits**: Do not exceed **12 requests/second** (burst up to 40/s)
@@ -51,18 +65,18 @@ Please respect ORCID's Public API policies:
 (per IP address)
 - **Polling**: Avoid continuously polling the API for changes
 
-See ORCID's References for more details.
-
-## ❗ Disclaimer
-This is a third-party tool and is not affiliated with, sponsored by, or endorsed by ORCID. It uses the ORCID Public API only to fetch public data. See ORCID’s *Public APIs Terms of Service* for complete usage rules.
+See ORCID's [References](#references) for more details.
 
 ## Contributing
 PRs and issues are welcome—please open an issue first to discuss major changes.
 
+## Disclaimer
+This is a third-party tool and is not affiliated with, sponsored by, or endorsed by ORCID. It uses the ORCID Public API only to fetch public data. See ORCID's [References](#references) for complete usage rules.
+
 ## References
-- ORCID ― [ORCID-Model](https://github.com/ORCID/orcid-model)
-- ORCID ― [Public APIs Terms of Service](https://info.orcid.org/public-client-terms-of-service)
-- ORCID ― [What are the API usage quotas and limits?](https://info.orcid.org/ufaqs/what-are-the-api-limits)
+- [ORCID/orcid-model - Github](https://github.com/ORCID/orcid-model)
+- [Public APIs Terms of Service - ORCID](https://info.orcid.org/public-client-terms-of-service)
+- [What are the API usage quotas and limits? - ORCID](https://info.orcid.org/ufaqs/what-are-the-api-limits)
 
 ## License
 Licensed under the Apache-2.0 License. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ cargo build --release
 ### `orcid-works-cli`
 #### Command
 ```bash
-orcid-works-cli --id $ORCID_iD [Options]
+orcid-works-cli --id $ORCID_ID [Options]
 ```
 
 #### Options
 | Flag | Description | Default |
 | :--- | :---------- | :------ |
-| `-i`, `--id` \<String\> | ORCID iD (e.g. `3141-5926-5358-9793`) | *(required)* |
+| `-i`, `--id` \<String\> | ORCID iD (e.g. `0000-0002-1825-0097`) | *(required)* |
 | `-o`, `--out` \<PathBuf\> | Output JSON file path (parent dirs auto-created) | `./output.json` |
 | `--concurrency` \<usize\> | Maximum parallel requests (1-32). Should not exceed rate-limit. | `8` |
 | `--rate-limit` \<u32\> | Requests-per-second cap (1–40). See [Guidelines](#guidelines) section. | `12` |
@@ -53,7 +53,7 @@ orcid-works-cli --id $ORCID_iD [Options]
 #### Example
 ```bash
 orcid-works-cli \
-    --id 3141-5926-5358-9793 \
+    --id "0000-0002-1825-0097" \
     --out ./output.json
 ```
 

--- a/crates/orcid-works-cli/Cargo.toml
+++ b/crates/orcid-works-cli/Cargo.toml
@@ -3,16 +3,19 @@ name = "orcid-works-cli"
 version = "0.1.0"
 edition = "2024"
 build   = "build.rs"
+license = "Apache-2.0"
 
 [dependencies]
 orcid-works-model = { path = "../orcid-works-model" }
-anyhow        = "1"
-futures       = "0.3"
-governor = { version = "0.10" }
-serde         = { version = "1", features = ["derive"] }
-serde_json    = "1"
-serde_path_to_error = "0.1"
-rayon         = "1"
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+futures = "0.3"
+governor = "0.10"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
-tokio   = { version = "1", features = ["rt-multi-thread", "macros"] }
-clap    = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_path_to_error = "0.1"
+tempfile = "3"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/crates/orcid-works-cli/src/io.rs
+++ b/crates/orcid-works-cli/src/io.rs
@@ -1,0 +1,102 @@
+use anyhow::{Context, Result};
+use serde_path_to_error::deserialize;
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter, ErrorKind, Write},
+    path::Path,
+};
+
+use tempfile::NamedTempFile;
+use tracing::{error, info, instrument, warn};
+
+use orcid_works_model::OrcidWorkDetailFile;
+
+// Read the existing JSON file; use the empty list if absent.
+#[instrument(name = "read_work_details_json", skip_all)]
+pub(crate) fn read_work_details_json<P: AsRef<Path>>(path: P) -> Result<OrcidWorkDetailFile> {
+    let path = path.as_ref();
+
+    match File::open(path) {
+        Ok(file) => {
+            let reader = BufReader::new(file);
+            let mut de = serde_json::Deserializer::from_reader(reader);
+
+            let data: OrcidWorkDetailFile = deserialize(&mut de).map_err(|e| {
+                error!(
+                    path = path.display().to_string(),
+                    err = %e,
+                    "JSON parse failure"
+                );
+                e
+            })?;
+
+            Ok(data)
+        }
+
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            info!(
+                path = path.display().to_string(),
+                "file not found; use empty JSON"
+            );
+            Ok(OrcidWorkDetailFile { records: vec![] })
+        }
+
+        Err(e) => {
+            error!(path= path.display().to_string(), err = %e, "failed to open work-detail file");
+            Err(e).with_context(|| format!("open {}", path.display()))
+        }
+    }
+}
+
+// Write JSON file
+#[instrument(name = "write_pretty_json", skip_all)]
+pub(crate) fn write_pretty_json<P: AsRef<Path>>(
+    path: P,
+    value: &OrcidWorkDetailFile,
+) -> Result<()> {
+    let path = path.as_ref();
+    let parent = path.parent().unwrap_or(Path::new("."));
+
+    let mut tmp = match NamedTempFile::new_in(parent)
+        .with_context(|| format!("create temp file for {}", path.display()))
+    {
+        Ok(f) => f,
+        Err(e) => {
+            error!(path = path.display().to_string(), err = %e, "failed to create temp file");
+            return Err(e);
+        }
+    };
+
+    if let Err(e) = serde_json::to_writer_pretty(BufWriter::new(&mut tmp), value)
+        .with_context(|| format!("serialize JSON into {}", path.display()))
+    {
+        error!(path = path.display().to_string(), err = %e, "JSON serialization failure");
+        return Err(e);
+    }
+
+    if let Err(e) = tmp.as_file_mut().flush() {
+        error!(path = path.display().to_string(), err = %e, "flush failure");
+        return Err(e).context("flush tmp file");
+    }
+    if let Err(e) = tmp.as_file_mut().sync_all() {
+        error!(path = path.display().to_string(), err = %e, "fsync failure");
+        return Err(e).context("fsync tmp file");
+    }
+
+    if let Err(e) = tmp
+        .persist(path)
+        .map_err(|e| e.error)
+        .with_context(|| format!("rename temp file into {}", path.display()))
+    {
+        error!(path = path.display().to_string(), err = %e, "atomic rename failure");
+        return Err(e);
+    }
+
+    if let Ok(dir) = parent.to_owned().canonicalize() {
+        if let Ok(dir_fd) = File::open(&dir) {
+            let _ = dir_fd.sync_all();
+        }
+    }
+
+    Ok(())
+}

--- a/crates/orcid-works-model/Cargo.toml
+++ b/crates/orcid-works-model/Cargo.toml
@@ -2,6 +2,7 @@
 name = "orcid-works-model"
 version = "0.1.0"
 edition = "2024"
+license = "Apache-2.0"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Fixes #2

### CHANGELOG v0.2.0
- Diff existing `WorkDetail` JSON against the latest summaries and download **only** new or updated entries
- `--force-fetch` flag to bypass the diff and refetch everything
- `tracing`-based logging

### How to try it
```jq
# filter.jq

# a) 0th: edit title & backdate last-modified-date (→ to be updated)
  (.records[0].title.title.value) |= "✨ Modified Title ✨"
| (.records[0]."last-modified-date".value) -= 86400000
# b) 1st) duplicate and change title & put-code (→ to be deleted)
| .records += [.records[1]]
| (.records[1]."put-code") |= 999999
| (.records[1].title.title.value) |= "🗑️ Deleted Title 🗑️"
# c) 2nd: remove (→ to be added)
| del(.records[2])
```

```shell
# test.sh

# 0) set your ORCID ID or sample ID
ORCID_ID="0000-0002-1825-0097"

# 1) initial fetch
cargo run -p orcid-works-cli -- -i "$ORCID_ID" -o output.json

# 2) mangle the JSON (requires at least 3 records)
jq -f filter.jq output.json > output-modified.json
cp output-modified.json output-modified-1.json
cp output-modified.json output-modified-2.json

# 3) refetch (diff-aware)
cargo run -p orcid-works-cli -- -i "$ORCID_ID" -o output-modified-1.json
# => only missing/changed records are fetched

# 3') force-fetch (bypass diff)
cargo run -p orcid-works-cli -- -i "$ORCID_ID" -o output-modified-2.json --force-fetch
# => all records are fetched

# 4) compare results (expected: identical)
diff -q output.json output-modified-1.json
diff -q output.json output-modified-2.json
```

#### Note
The example below uses ORCID's *public sample record* **0000-0002-1825-0097**. Feel free to replace it with **any real ORCID iD** you own or wish to test. A non-existent ORCID iD will cause the API to return **404 Not Found**.
