### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "orcid-works-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "orcid-works-model"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/orcid-works-cli/Cargo.toml
+++ b/crates/orcid-works-cli/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "orcid-works-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 build   = "build.rs"
 license = "Apache-2.0"
 
 [dependencies]
-orcid-works-model = { path = "../orcid-works-model" }
+orcid-works-model = { path = "../orcid-works-model" , version = "0.2.0" }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"

--- a/crates/orcid-works-model/Cargo.toml
+++ b/crates/orcid-works-model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orcid-works-model"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
### What's inside
- Bump `version` fields to **0.2.0** (`orcid-works-cli`, `orcid-works-model`)
- Regenerate `Cargo.lock`