### PR TITLE
docs(examples): add example scripts for orcid-works-cli

### DIFF
--- a/examples/orcid-works/filter.jq
+++ b/examples/orcid-works/filter.jq
@@ -1,0 +1,9 @@
+# a) 0th: edit title & backdate last-modified-date (→ to be updated)
+  (.records[0].title.title.value) |= "Title to be updated"
+| (.records[0]."last-modified-date".value) -= 86400000
+# b) 1st) duplicate and change title & put-code (→ to be deleted)
+| .records += [.records[1]]
+| (.records[1]."put-code") |= 999999
+| (.records[1].title.title.value) |= "Title to be deleted"
+# c) 2nd: remove (→ to be added)
+| del(.records[2])

--- a/examples/orcid-works/test.ps1
+++ b/examples/orcid-works/test.ps1
@@ -1,0 +1,24 @@
+#!/usr/bin/env pwsh
+
+# 0) set your ORCID ID or sample ID
+$ORCID_ID = "0000-0002-1825-0097"
+
+# 1) initial fetch
+cargo run -p orcid-works-cli -- -i "$ORCID_ID" -o output.json
+
+# 2) mangle the JSON (requires at least 3 records)
+jq -f filter.jq output.json > output-modified.json
+Copy-Item output-modified.json -Destination output-modified-1.json
+Copy-Item output-modified.json -Destination output-modified-2.json
+
+# 3) refetch (diff-aware)
+cargo run -p orcid-works-cli -- -i "$ORCID_ID" -o output-modified-1.json
+# => only missing/changed records are fetched
+
+# 3') force-fetch (bypass diff)
+cargo run -p orcid-works-cli -- -i "$ORCID_ID" -o output-modified-2.json --force-fetch
+# => all records are fetched
+
+# 4) compare results (expected: identical)
+Compare-Object output.json output-modified-1.json
+Compare-Object output.json output-modified-2.json

--- a/examples/orcid-works/test.sh
+++ b/examples/orcid-works/test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# 0) set your ORCID ID or sample ID
+ORCID_ID="0000-0002-1825-0097"
+
+# 1) initial fetch
+cargo run -p orcid-works-cli -- -i "$ORCID_ID" -o output.json
+
+# 2) mangle the JSON (requires at least 3 records)
+jq -f filter.jq output.json > output-modified.json
+cp output-modified.json output-modified-1.json
+cp output-modified.json output-modified-2.json
+
+# 3) refetch (diff-aware)
+cargo run -p orcid-works-cli -- -i "$ORCID_ID" -o output-modified-1.json
+# => only missing/changed records are fetched
+
+# 3') force-fetch (bypass diff)
+cargo run -p orcid-works-cli -- -i "$ORCID_ID" -o output-modified-2.json --force-fetch
+# => all records are fetched
+
+# 4) compare results (expected: identical)
+diff -q output.json output-modified-1.json
+diff -q output.json output-modified-2.json


### PR DESCRIPTION
Adds two example scripts (Bash & PowerShell) that demonstrate the delta‑fetch feature of `orcid-works‑cli`.

### What's new

#### `examples/orcid-works/test.sh`
Bash script that  
1. fetches ORCID Works (Detail) and saves them as `output.json`;  
2. mutates the file with `filter.jq`;  
3. re-runs the CLI with and without the `--force-fetch` flag to compare diff‑fetch behaviour.

This script is based on the *How to try it* section in PR #3.

#### `examples/orcid-works/test.ps1`
Functionally identical **PowerShell** version of the script above.

#### `examples/orcid-works/filter.jq`
Re‑usable `jq` filter used to tweak the JSON between fetch runs.
